### PR TITLE
fix: update the Makefile so that that install command can execute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ publish_pacts: .env
 ## Build/test tasks
 ## =====================
 
-install: npm install 
+install: 
+	npm install 
 
 test: .env
 	@echo "\n========== STAGE: test ✅ (cypress) ==========\n"


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `Makefile` to fix an issue where the `install` command was not properly formatted. The `npm install` command has been moved to a new line under the `install` target.
> 
> ## What changed
> The `Makefile` was updated. Previously, the `install` target and the `npm install` command were on the same line. This has been changed so that the `npm install` command is now on a new line under the `install` target.
> 
> ```diff
> -install: npm install 
> +install: 
> +	npm install 
> ```
> 
> ## How to test
> To test this change, you can run the `install` command from the `Makefile`. This should now correctly run the `npm install` command. If the `npm install` command runs without any issues, then the change has been implemented correctly.
> 
> ## Why make this change
> This change was necessary because the `install` command was not properly formatted in the `Makefile`. This could potentially cause issues when trying to run the `install` command. By moving the `npm install` command to a new line under the `install` target, we ensure that the `install` command is correctly formatted and can be run without any issues.
</details>