### PR TITLE
fix: update the Makefile so that that install command can execute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ publish_pacts: .env
 ## Build/test tasks
 ## =====================
 
-install: npm install 
+install: 
+	npm install 
 
 test: .env
 	@echo "\n========== STAGE: test ✅ (cypress) ==========\n"


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `Makefile` to fix an issue where the `install` command was not properly formatted. The `npm install` command is now correctly placed on a new line under the `install` target.
> 
> ## What changed
> The `install` target in the `Makefile` was previously written as `install: npm install`. This has been changed to:
> 
> ```
> install: 
> 	npm install 
> ```
> 
> This change ensures that the `npm install` command is correctly executed when the `install` target is invoked.
> 
> ## How to test
> To test this change, you can run the `install` target from the `Makefile` by executing the following command in your terminal:
> 
> ```
> make install
> ```
> 
> This should correctly execute the `npm install` command.
> 
> ## Why make this change
> This change was necessary because the previous formatting of the `install` target was causing issues with the execution of the `npm install` command. By placing the `npm install` command on a new line under the `install` target, we ensure that the command is correctly executed when the `install` target is invoked. This will improve the reliability of our build process.
</details>