### PR TITLE
chore: update ESLint ECMA version to 2023

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
     "ecmaFeatures": {
       "jsx": true
     },
-    "ecmaVersion": 2018,
+    "ecmaVersion": 2023,
     "sourceType": "module"
   },
   "plugins": [


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the ECMAScript version in our ESLint configuration from 2018 to 2023.
> 
> ## What changed
> The `.eslintrc.json` file was modified to change the `ecmaVersion` from 2018 to 2023. This change will allow us to use the latest ECMAScript features in our codebase.
> 
> ```diff
> diff --git a/.eslintrc.json b/.eslintrc.json
> index b1250a9..cea62c5 100644
> --- a/.eslintrc.json
> +++ b/.eslintrc.json
> @@ -24,7 +24,7 @@
>      "ecmaFeatures": {
>        "jsx": true
>      },
> -    "ecmaVersion": 2018,
> +    "ecmaVersion": 2023,
>      "sourceType": "module"
>    },
>    "plugins": [
> ```
> 
> ## How to test
> After pulling the changes, you can test this by writing some code that uses features introduced in ECMAScript 2023. If ESLint does not throw any parsing errors, then the change has been successful.
> 
> ## Why make this change
> Updating the `ecmaVersion` to 2023 allows us to use the latest ECMAScript features, which can help us write more modern and efficient code. It also ensures that our linter is up-to-date with the latest JavaScript standards, helping us catch potential issues and maintain a high-quality codebase.
</details>