### PR TITLE
ci: update the build and pipeline files to handle the latest version of all tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "18"
       - name: Install
         run: npm i
       - name: Test

--- a/.github/workflows/test_pact_cli_tools_cross_os.yml
+++ b/.github/workflows/test_pact_cli_tools_cross_os.yml
@@ -15,7 +15,7 @@ on:
       PACT_CLI_STANDALONE_VERSION:
         description: Tag from https://github.com/pact-foundation/pact-ruby-standalone/releases
         required: true
-        default: 1.89.00
+        default: 2.4.1
         type: string
 
 env:
@@ -27,7 +27,7 @@ env:
   PACT_CLI_VERSION: ${{ github.event.inputs.PACT_CLI_VERSION }}
   PACT_CLI_DOCKER_VERSION: ${{ github.event.inputs.PACT_CLI_DOCKER_VERSION }}
   PACT_CLI_STANDALONE_VERSION: ${{ github.event.inputs.PACT_CLI_STANDALONE_VERSION }}
-  PACT_CLI_STANDALONE_VERSION_DEFAULT: 1.88.90
+  PACT_CLI_STANDALONE_VERSION_DEFAULT: 2.4.1
 
 jobs:
 
@@ -51,9 +51,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest','macos-latest']
-        pact_tool: ['docker', 'ruby_cli','ruby_standalone' ]
-        node-version: [14.x,16.x]
+        os: 
+          [
+            'ubuntu-latest',
+            'windows-latest',
+            'macos-latest'
+          ]
+        pact_tool: 
+          [
+            'docker',
+            'ruby_cli',
+            'ruby_standalone'
+          ]
+        node-version: 
+          [
+            18.x,
+            20.x
+          ]
         pact_provider:
           [
             "pactflow-example-bi-directional-provider-dredd",
@@ -79,7 +93,7 @@ jobs:
         uses: ruby/setup-ruby@v1 
         if: ${{ (env.PACT_TOOL == 'ruby_cli' || env.PACT_TOOL == 'ruby_standalone') && runner.os == 'Linux' }}
         with:
-          ruby-version: 2.7
+          ruby-version: 3.3
           bundler: none
       # we add a fallback for windows/darwin runners as they cannot run docker
       - name: 🔧 install-pact-ruby-cli (also runs for macOS/docker) 

--- a/Makefile
+++ b/Makefile
@@ -190,13 +190,13 @@ uninstall-pact-ruby-cli:
 
 install-pact-ruby-standalone:
 	case "${detected_OS}" in \
-	Windows|MSYS) curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-win32.zip && \
-		unzip pact-${PACT_CLI_STANDALONE_VERSION}-win32.zip && \
+	Windows|MSYS) curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-windows-x86_64.zip && \
+		unzip pact-${PACT_CLI_STANDALONE_VERSION}-windows-x86_64.zip && \
 		./pact/bin/pact-mock-service.bat --help && \
 		./pact/bin/pact-provider-verifier.bat --help && \
 		./pact/bin/pactflow.bat help;; \
-	Darwin) curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-osx.tar.gz && \
-		tar xzf pact-${PACT_CLI_STANDALONE_VERSION}-osx.tar.gz && \
+	Darwin) curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-osx-x86_64.tar.gz && \
+		tar xzf pact-${PACT_CLI_STANDALONE_VERSION}-osx-x86_64.tar.gz && \
 		./pact/bin/pact-mock-service --help && \
 		./pact/bin/pact-provider-verifier --help && \
 		./pact/bin/pactflow help;; \

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ SHELL := /bin/bash
 PACT_TOOL?=docker
 PACT_CLI_DOCKER_VERSION?=latest
 PACT_CLI_VERSION?=latest
-PACT_CLI_STANDALONE_VERSION?=1.89.00
+PACT_CLI_STANDALONE_VERSION?=2.4.1
 PACT_CLI_DOCKER_RUN_COMMAND?=docker run --rm -v /${PWD}:/${PWD} -w ${PWD} -e PACT_BROKER_BASE_URL -e PACT_BROKER_TOKEN pactfoundation/pact-cli:${PACT_CLI_DOCKER_VERSION}
 PACT_BROKER_COMMAND=pact-broker
 PACTFLOW_CLI_COMMAND=pactflow
@@ -154,7 +154,7 @@ PACTFLOW_CLI_COMMAND=pactflow
 ifeq '$(findstring ;,$(PATH))' ';'
 	detected_OS := Windows
 else
-	detected_OS := $(shell uname 2>/dev/null || echo Unknown)
+	detected_OS := $(shell uname -sm 2>/dev/null || echo Unknown)
 	detected_OS := $(patsubst CYGWIN%,Cygwin,$(detected_OS))
 	detected_OS := $(patsubst MSYS%,MSYS,$(detected_OS))
 	detected_OS := $(patsubst MINGW%,MSYS,$(detected_OS))
@@ -195,12 +195,22 @@ install-pact-ruby-standalone:
 		./pact/bin/pact-mock-service.bat --help && \
 		./pact/bin/pact-provider-verifier.bat --help && \
 		./pact/bin/pactflow.bat help;; \
-	Darwin) curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-osx-x86_64.tar.gz && \
+	"Darwin arm64") curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-osx-arm64.tar.gz && \
+		tar xzf pact-${PACT_CLI_STANDALONE_VERSION}-osx-arm64.tar.gz && \
+		./pact/bin/pact-mock-service --help && \
+		./pact/bin/pact-provider-verifier --help && \
+		./pact/bin/pactflow help;; \
+	"Darwin x86_64") curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-osx-x86_64.tar.gz && \
 		tar xzf pact-${PACT_CLI_STANDALONE_VERSION}-osx-x86_64.tar.gz && \
 		./pact/bin/pact-mock-service --help && \
 		./pact/bin/pact-provider-verifier --help && \
 		./pact/bin/pactflow help;; \
-	Linux) curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-linux-x86_64.tar.gz && \
+	"Linux aarch64") curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-linux-arm64.tar.gz && \
+		tar xzf pact-${PACT_CLI_STANDALONE_VERSION}-linux-arm64.tar.gz && \
+		./pact/bin/pact-mock-service --help && \
+		./pact/bin/pact-provider-verifier --help && \
+		./pact/bin/pactflow help;; \
+	"Linux x86_64") curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_CLI_STANDALONE_VERSION}/pact-${PACT_CLI_STANDALONE_VERSION}-linux-x86_64.tar.gz && \
 		tar xzf pact-${PACT_CLI_STANDALONE_VERSION}-linux-x86_64.tar.gz && \
 		./pact/bin/pact-mock-service --help && \
 		./pact/bin/pact-provider-verifier --help && \


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the Node.js version, Pact CLI Standalone version, Ruby version, and the operating systems and tools matrix for GitHub Actions. It also updates the download links for the Pact Ruby Standalone in the Makefile.
> 
> ## What changed
> - The Node.js version in the GitHub Actions workflow was updated from 14 to 18.
> - The default Pact CLI Standalone version was updated from 1.89.00 to 2.4.1.
> - The Ruby version was updated from 2.7 to 3.3.
> - The operating systems and tools matrix for GitHub Actions was updated to include Node.js versions 18.x and 20.x.
> - The download links for the Pact Ruby Standalone in the Makefile were updated to reflect the new version and architecture.
> 
> ## How to test
> To test these changes, you can trigger the GitHub Actions workflows and check if they run successfully with the updated versions and configurations. You can also run the Makefile commands to install the Pact Ruby Standalone and verify if it downloads and installs the correct version.
> 
> ## Why make this change
> - These changes were made to keep the project up-to-date with the latest versions of Node.js, Ruby, and Pact CLI Standalone. 
> - This can help improve the performance, security, and compatibility of the project. 
> - The updates to the GitHub Actions workflows and Makefile also ensure that the correct versions and configurations are used in the CI/CD pipeline and local development environment.
</details>