### PR TITLE
chore: remove unused packages and upgrade vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,19 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.6.7",
-        "lodash": "^4.17.21",
         "prop-types": "15.8.1",
         "react": "^18.2.0",
         "react-dom": "18.2.0",
         "react-router": "^6.22.1",
         "react-router-dom": "^6.22.1",
         "react-scripts": "^5.0.1",
-        "spectre.css": "^0.5.9",
-        "swagger-mock-validator": "^10.0.0"
+        "spectre.css": "^0.5.9"
       },
       "devDependencies": {
         "@pactflow/pact-cypress-adapter": "^1.3.0",
         "@testing-library/jest-dom": "6.4.2",
         "@types/eslint": "~8.56.3",
         "@types/lint-staged": "~13.3.0",
-        "@types/lodash": "~4.14.202",
         "@types/prop-types": "~15.7.11",
         "@types/react": "~18.2.58",
         "@types/react-dom": "~18.2.19",
@@ -33,7 +30,6 @@
         "babel-eslint": "^10.1.0",
         "cross-env": "^7.0.3",
         "cypress": "^13.6.6",
-        "dotenv": "^8.2.0",
         "eslint": "^8.56.0",
         "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-cypress": "^2.15.1",
@@ -83,41 +79,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/@apidevtools/openapi-schemas": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
-    "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^4.2.3"
-      },
-      "peerDependencies": {
-        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2050,7 +2011,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-color-function": {
@@ -2069,7 +2030,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-font-format-keywords": {
@@ -2087,7 +2048,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-hwb-function": {
@@ -2105,7 +2066,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-ic-unit": {
@@ -2124,7 +2085,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class": {
@@ -2143,7 +2104,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-nested-calc": {
@@ -2161,7 +2122,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-normalize-display-values": {
@@ -2179,7 +2140,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-oklab-function": {
@@ -2198,7 +2159,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-progressive-custom-properties": {
@@ -2212,7 +2173,7 @@
         "node": "^12 || ^14 || >=16"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-stepped-value-functions": {
@@ -2230,7 +2191,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-text-decoration-shorthand": {
@@ -2248,7 +2209,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-trigonometric-functions": {
@@ -2266,7 +2227,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-unset-value": {
@@ -2281,7 +2242,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/selector-specificity": {
@@ -3387,9 +3348,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.4.tgz",
-      "integrity": "sha512-Oud2QPM5dHviZNn4y/WhhYKSXksv+1xLEIsNrAbGcFzUN3ubqWRFT5gwPchNc5NuzILOU4tPBDTZ4VwhL8Y7cw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3430,17 +3391,13 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.23.tgz",
-      "integrity": "sha512-9/4foRoUKp8s96tSkh8DlAAc5A0Ty8vLXld+l9gjKKY6ckwI8G15f0hskGmuLZu78ZlGa1vtsfOa+lnB4vG6Jg==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -4381,9 +4338,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
+      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg=="
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -5591,6 +5548,7 @@
     },
     "node_modules/asn1": {
       "version": "0.2.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -5598,6 +5556,7 @@
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -5665,7 +5624,7 @@
         "node": "^10 || ^12 || >=14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -5697,6 +5656,7 @@
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -5704,6 +5664,7 @@
     },
     "node_modules/aws4": {
       "version": "1.9.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/axe-core": {
@@ -6095,6 +6056,7 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -6482,10 +6444,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -6564,6 +6522,7 @@
     },
     "node_modules/caseless": {
       "version": "0.12.0",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/chalk": {
@@ -7251,7 +7210,7 @@
         "node": "^10 || ^12 || >=14"
       },
       "peerDependencies": {
-        "postcss": "^8.0.9"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/css-has-pseudo": {
@@ -7277,7 +7236,7 @@
       "integrity": "sha512-LTSA/jWbwdMlk+rhmElbDR2vbtQoTBPr7fkJE+mxrHj+7ru0hUmHafDRzWIjIHTwpitWVaqY2/UWGRca3yUgRw==",
       "dependencies": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
+        "postcss": "^8.4.35",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.4",
         "postcss-modules-scope": "^3.1.1",
@@ -7337,9 +7296,9 @@
       "dependencies": {
         "cssnano": "^5.0.6",
         "jest-worker": "^27.0.2",
-        "postcss": "^8.3.5",
+        "postcss": "^8.4.35",
         "schema-utils": "^4.0.0",
-        "serialize-javascript": "^6.0.0",
+        "serialize-javascript": "^6.0.2",
         "source-map": "^0.6.1"
       },
       "engines": {
@@ -7474,7 +7433,7 @@
         "css-what": "^6.0.1",
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
+        "nth-check": "^2.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
@@ -7556,7 +7515,7 @@
         "url": "https://opencollective.com/cssnano"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/cssnano-preset-default": {
@@ -7598,7 +7557,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/cssnano-utils": {
@@ -7609,7 +7568,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/csso": {
@@ -7931,6 +7890,7 @@
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -8303,14 +8263,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/dotenv": {
-      "version": "8.2.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
       "license": "BSD-2-Clause"
@@ -8326,6 +8278,7 @@
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
@@ -9944,6 +9897,7 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/extract-zip": {
@@ -9981,6 +9935,7 @@
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -10306,6 +10261,7 @@
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -10494,6 +10450,7 @@
     },
     "node_modules/form-data": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -10713,6 +10670,7 @@
     },
     "node_modules/getpass": {
       "version": "0.1.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -10877,24 +10835,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/harmony-reflect": {
       "version": "1.6.1",
@@ -11231,19 +11171,6 @@
         }
       }
     },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -11297,7 +11224,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/idb": {
@@ -11914,6 +11841,7 @@
     },
     "node_modules/isstream": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -14815,6 +14743,7 @@
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -14976,9 +14905,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
-    "node_modules/json-schema": {
-      "version": "0.2.3"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "license": "MIT"
@@ -14989,6 +14915,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -15045,23 +14972,11 @@
       }
     },
     "node_modules/jsonpointer": {
-      "version": "4.1.0",
-      "license": "MIT",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.1",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -15710,14 +15625,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -16599,13 +16506,6 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
       "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
@@ -16799,10 +16699,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openapi-types": {
-      "version": "7.2.3",
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.8.3",
@@ -17306,7 +17202,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-browser-comments": {
@@ -17330,7 +17226,7 @@
         "postcss-value-parser": "^4.2.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.2"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-clamp": {
@@ -17344,7 +17240,7 @@
         "node": ">=7.6.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.6"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-color-functional-notation": {
@@ -17362,7 +17258,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-color-hex-alpha": {
@@ -17398,7 +17294,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-colormin": {
@@ -17415,7 +17311,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-convert-values": {
@@ -17430,7 +17326,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-custom-media": {
@@ -17448,7 +17344,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-custom-properties": {
@@ -17466,7 +17362,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-custom-selectors": {
@@ -17484,7 +17380,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-dir-pseudo-class": {
@@ -17502,7 +17398,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-discard-comments": {
@@ -17513,7 +17409,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-discard-duplicates": {
@@ -17524,7 +17420,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-discard-empty": {
@@ -17535,7 +17431,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-discard-overridden": {
@@ -17546,7 +17442,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-double-position-gradients": {
@@ -17565,7 +17461,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-env-function": {
@@ -17587,7 +17483,7 @@
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
       "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
       "peerDependencies": {
-        "postcss": "^8.1.4"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-focus-visible": {
@@ -17623,7 +17519,7 @@
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
       "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-gap-properties": {
@@ -17638,7 +17534,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-image-set-function": {
@@ -17656,7 +17552,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-import": {
@@ -17672,7 +17568,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "postcss": "^8.0.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-initial": {
@@ -17680,7 +17576,7 @@
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
       "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
       "peerDependencies": {
-        "postcss": "^8.0.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-js": {
@@ -17698,7 +17594,7 @@
         "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
-        "postcss": "^8.4.21"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-lab-function": {
@@ -17717,7 +17613,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-load-config": {
@@ -17742,7 +17638,7 @@
         "node": ">= 14"
       },
       "peerDependencies": {
-        "postcss": ">=8.0.9",
+        "postcss": ">=8.4.35",
         "ts-node": ">=9.0.0"
       },
       "peerDependenciesMeta": {
@@ -17790,7 +17686,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "postcss": "^7.0.0 || ^8.0.1",
+        "postcss": "^8.4.35",
         "webpack": "^5.0.0"
       }
     },
@@ -17838,7 +17734,7 @@
         "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-merge-longhand": {
@@ -17853,7 +17749,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-merge-rules": {
@@ -17870,7 +17766,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-minify-font-values": {
@@ -17884,7 +17780,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-minify-gradients": {
@@ -17900,7 +17796,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-minify-params": {
@@ -17916,7 +17812,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-minify-selectors": {
@@ -17930,7 +17826,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -17941,7 +17837,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-modules-local-by-default": {
@@ -17957,7 +17853,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-modules-scope": {
@@ -17971,7 +17867,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-modules-values": {
@@ -17985,7 +17881,7 @@
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
-        "postcss": "^8.1.0"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-nested": {
@@ -18003,7 +17899,7 @@
         "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
-        "postcss": "^8.2.14"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-nesting": {
@@ -18022,7 +17918,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-normalize": {
@@ -18039,7 +17935,7 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4",
-        "postcss": ">= 8"
+        "postcss": ">= 8.4"
       }
     },
     "node_modules/postcss-normalize-charset": {
@@ -18050,7 +17946,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-normalize-display-values": {
@@ -18064,7 +17960,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-normalize-positions": {
@@ -18078,7 +17974,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
@@ -18092,7 +17988,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-normalize-string": {
@@ -18106,7 +18002,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
@@ -18120,7 +18016,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-normalize-unicode": {
@@ -18135,7 +18031,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-normalize-url": {
@@ -18150,7 +18046,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-normalize-whitespace": {
@@ -18164,7 +18060,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-opacity-percentage": {
@@ -18185,7 +18081,7 @@
         "node": "^12 || ^14 || >=16"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-ordered-values": {
@@ -18200,7 +18096,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-overflow-shorthand": {
@@ -18218,7 +18114,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-page-break": {
@@ -18226,7 +18122,7 @@
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
       "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
       "peerDependencies": {
-        "postcss": "^8"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-place": {
@@ -18244,7 +18140,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-preset-env": {
@@ -18310,7 +18206,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-pseudo-class-any-link": {
@@ -18328,7 +18224,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-reduce-initial": {
@@ -18343,7 +18239,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-reduce-transforms": {
@@ -18357,7 +18253,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-replace-overflow-wrap": {
@@ -18365,7 +18261,7 @@
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
       "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
       "peerDependencies": {
-        "postcss": "^8.0.3"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-selector-not": {
@@ -18383,7 +18279,7 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -18410,7 +18306,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-svgo/node_modules/commander": {
@@ -18469,7 +18365,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -18694,13 +18590,6 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/querystringify": {
@@ -19061,7 +18950,7 @@
         "jest-resolve": "^27.4.2",
         "jest-watch-typeahead": "^1.0.0",
         "mini-css-extract-plugin": "^2.4.5",
-        "postcss": "^8.4.4",
+        "postcss": "^8.4.35",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^6.2.1",
         "postcss-normalize": "^10.0.1",
@@ -20967,35 +20856,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "dev": true,
@@ -21068,7 +20928,7 @@
         "adjust-sourcemap-loader": "^4.0.0",
         "convert-source-map": "^1.7.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^7.0.35",
+        "postcss": "^8.4.35",
         "source-map": "0.6.1"
       },
       "engines": {
@@ -21098,9 +20958,9 @@
       "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
     },
     "node_modules/resolve-url-loader/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "dependencies": {
         "picocolors": "^0.2.1",
         "source-map": "^0.6.1"
@@ -21193,7 +21053,7 @@
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
+        "serialize-javascript": "^6.0.2",
         "terser": "^5.0.0"
       },
       "peerDependencies": {
@@ -21222,9 +21082,9 @@
       }
     },
     "node_modules/rollup-plugin-terser/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -21869,6 +21729,7 @@
     },
     "node_modules/sshpk": {
       "version": "1.16.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
@@ -22229,7 +22090,7 @@
         "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.35"
       }
     },
     "node_modules/sucrase": {
@@ -22396,7 +22257,7 @@
         "boolbase": "^1.0.0",
         "css-what": "^3.2.1",
         "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "nth-check": "^2.1.1"
       }
     },
     "node_modules/svgo/node_modules/css-what": {
@@ -22434,52 +22295,11 @@
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "node_modules/svgo/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dependencies": {
         "boolbase": "~1.0.0"
-      }
-    },
-    "node_modules/swagger-mock-validator": {
-      "version": "10.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^6.10.0",
-        "commander": "^6.1.0",
-        "decimal.js": "^10.2.0",
-        "js-yaml": "^3.12.0",
-        "jsonpointer": "^4.0.1",
-        "lodash": "^4.17.10",
-        "openapi-types": "^7.0.1",
-        "request": "^2.87.0",
-        "swagger-parser": "^10.0.2",
-        "uuidjs": "^4.0.3",
-        "validator": "^13.1.17",
-        "verror": "^1.8.1"
-      },
-      "bin": {
-        "swagger-mock-validator": "bin/swagger-mock-validator"
-      },
-      "engines": {
-        "node": ">=6.14.3"
-      }
-    },
-    "node_modules/swagger-mock-validator/node_modules/commander": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/swagger-parser": {
-      "version": "10.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/swagger-parser": "10.0.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/symbol-tree": {
@@ -22506,7 +22326,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
+        "postcss": "^8.4.35",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
         "postcss-load-config": "^4.0.1",
@@ -22669,7 +22489,7 @@
         "@jridgewell/trace-mapping": "^0.3.20",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
+        "serialize-javascript": "^6.0.2",
         "terser": "^5.26.0"
       },
       "engines": {
@@ -22853,17 +22673,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tr46": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
@@ -22928,6 +22737,7 @@
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -22938,6 +22748,7 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -23500,20 +23311,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "3.3.3",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/uuidjs": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "bin": {
-        "uuidjs": "bin/cli.js"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
@@ -23542,13 +23339,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/validator": {
-      "version": "13.5.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -23559,6 +23349,7 @@
     },
     "node_modules/verror": {
       "version": "1.10.0",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -24103,8 +23894,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "license": "MIT",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24227,14 +24019,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/workbox-build/node_modules/jsonpointer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/workbox-build/node_modules/source-map": {
       "version": "0.8.0-beta.0",
@@ -24622,31 +24406,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/z-schema": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^12.0.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^2.7.1"
-      }
-    },
-    "node_modules/z-schema/node_modules/validator": {
-      "version": "12.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
     }
   },
   "dependencies": {
@@ -24673,31 +24432,6 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.7",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "@apidevtools/openapi-schemas": {
-      "version": "2.0.4"
-    },
-    "@apidevtools/swagger-methods": {
-      "version": "3.0.2"
-    },
-    "@apidevtools/swagger-parser": {
-      "version": "10.0.2",
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^4.2.3"
       }
     },
     "@babel/code-frame": {
@@ -26922,9 +26656,9 @@
       }
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.4.tgz",
-      "integrity": "sha512-Oud2QPM5dHviZNn4y/WhhYKSXksv+1xLEIsNrAbGcFzUN3ubqWRFT5gwPchNc5NuzILOU4tPBDTZ4VwhL8Y7cw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -26956,16 +26690,13 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.23.tgz",
-      "integrity": "sha512-9/4foRoUKp8s96tSkh8DlAAc5A0Ty8vLXld+l9gjKKY6ckwI8G15f0hskGmuLZu78ZlGa1vtsfOa+lnB4vG6Jg==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "@jsdevtools/ono": {
-      "version": "7.1.3"
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -27689,9 +27420,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
+      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg=="
     },
     "@types/send": {
       "version": "0.17.4",
@@ -28538,12 +28269,14 @@
     },
     "asn1": {
       "version": "0.2.4",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.8",
@@ -28601,10 +28334,12 @@
       }
     },
     "aws-sign2": {
-      "version": "0.7.0"
+      "version": "0.7.0",
+      "dev": true
     },
     "aws4": {
-      "version": "1.9.0"
+      "version": "1.9.0",
+      "dev": true
     },
     "axe-core": {
       "version": "4.7.0",
@@ -28915,6 +28650,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -29192,9 +28928,6 @@
         "set-function-length": "^1.2.1"
       }
     },
-    "call-me-maybe": {
-      "version": "1.0.1"
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -29248,7 +28981,8 @@
       "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw=="
     },
     "caseless": {
-      "version": "0.12.0"
+      "version": "0.12.0",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -29735,7 +29469,7 @@
       "integrity": "sha512-LTSA/jWbwdMlk+rhmElbDR2vbtQoTBPr7fkJE+mxrHj+7ru0hUmHafDRzWIjIHTwpitWVaqY2/UWGRca3yUgRw==",
       "requires": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
+        "postcss": "^8.4.35",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.4",
         "postcss-modules-scope": "^3.1.1",
@@ -29769,9 +29503,9 @@
       "requires": {
         "cssnano": "^5.0.6",
         "jest-worker": "^27.0.2",
-        "postcss": "^8.3.5",
+        "postcss": "^8.4.35",
         "schema-utils": "^4.0.0",
-        "serialize-javascript": "^6.0.0",
+        "serialize-javascript": "^6.0.2",
         "source-map": "^0.6.1"
       },
       "dependencies": {
@@ -29850,7 +29584,7 @@
         "css-what": "^6.0.1",
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
+        "nth-check": "^2.1.1"
       }
     },
     "css-select-base-adapter": {
@@ -30170,6 +29904,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -30434,10 +30169,6 @@
         }
       }
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "dev": true
-    },
     "dotenv-expand": {
       "version": "5.1.0"
     },
@@ -30451,6 +30182,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -31568,7 +31300,8 @@
       }
     },
     "extend": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "dev": true
     },
     "extract-zip": {
       "version": "2.0.1",
@@ -31590,7 +31323,8 @@
       }
     },
     "extsprintf": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -31834,7 +31568,8 @@
       }
     },
     "forever-agent": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "dev": true
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.3",
@@ -31957,6 +31692,7 @@
     },
     "form-data": {
       "version": "2.3.3",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -32098,6 +31834,7 @@
     },
     "getpass": {
       "version": "0.1.7",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -32211,16 +31948,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
-    },
-    "har-schema": {
-      "version": "2.0.0"
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
     },
     "harmony-reflect": {
       "version": "1.6.1"
@@ -32449,14 +32176,6 @@
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
         "micromatch": "^4.0.2"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -32878,7 +32597,8 @@
       "version": "2.0.0"
     },
     "isstream": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -35121,7 +34841,8 @@
       }
     },
     "jsbn": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dev": true
     },
     "jsdom": {
       "version": "16.7.0",
@@ -35225,9 +34946,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
-    "json-schema": {
-      "version": "0.2.3"
-    },
     "json-schema-traverse": {
       "version": "0.4.1"
     },
@@ -35235,7 +34953,8 @@
       "version": "1.0.1"
     },
     "json-stringify-safe": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "json5": {
       "version": "2.2.3",
@@ -35275,16 +34994,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0"
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
     },
     "jsx-ast-utils": {
       "version": "3.3.5",
@@ -35716,12 +35428,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "lodash.get": {
-      "version": "4.4.2"
-    },
-    "lodash.isequal": {
-      "version": "4.5.0"
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -36374,9 +36080,6 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
       "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
     },
-    "oauth-sign": {
-      "version": "0.9.0"
-    },
     "object-assign": {
       "version": "4.1.1"
     },
@@ -36506,9 +36209,6 @@
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
       }
-    },
-    "openapi-types": {
-      "version": "7.2.3"
     },
     "optionator": {
       "version": "0.8.3",
@@ -37677,9 +37377,6 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
-    "qs": {
-      "version": "6.5.2"
-    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -37941,7 +37638,7 @@
         "jest-resolve": "^27.4.2",
         "jest-watch-typeahead": "^1.0.0",
         "mini-css-extract-plugin": "^2.4.5",
-        "postcss": "^8.4.4",
+        "postcss": "^8.4.35",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^6.2.1",
         "postcss-normalize": "^10.0.1",
@@ -39349,31 +39046,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "request-progress": {
       "version": "3.0.0",
       "dev": true,
@@ -39427,7 +39099,7 @@
         "adjust-sourcemap-loader": "^4.0.0",
         "convert-source-map": "^1.7.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^7.0.35",
+        "postcss": "^8.4.35",
         "source-map": "0.6.1"
       },
       "dependencies": {
@@ -39442,9 +39114,9 @@
           "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
         },
         "postcss": {
-          "version": "7.0.39",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "version": "8.4.35",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+          "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
           "requires": {
             "picocolors": "^0.2.1",
             "source-map": "^0.6.1"
@@ -39504,7 +39176,7 @@
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
+        "serialize-javascript": "^6.0.2",
         "terser": "^5.0.0"
       },
       "dependencies": {
@@ -39524,9 +39196,9 @@
           }
         },
         "serialize-javascript": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+          "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
           "requires": {
             "randombytes": "^2.1.0"
           }
@@ -40007,6 +39679,7 @@
     },
     "sshpk": {
       "version": "1.16.1",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -40373,7 +40046,7 @@
             "boolbase": "^1.0.0",
             "css-what": "^3.2.1",
             "domutils": "^1.7.0",
-            "nth-check": "^1.0.2"
+            "nth-check": "^2.1.1"
           }
         },
         "css-what": {
@@ -40407,41 +40080,13 @@
           }
         },
         "nth-check": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-          "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+          "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
           "requires": {
             "boolbase": "~1.0.0"
           }
         }
-      }
-    },
-    "swagger-mock-validator": {
-      "version": "10.0.0",
-      "requires": {
-        "ajv": "^6.10.0",
-        "commander": "^6.1.0",
-        "decimal.js": "^10.2.0",
-        "js-yaml": "^3.12.0",
-        "jsonpointer": "^4.0.1",
-        "lodash": "^4.17.10",
-        "openapi-types": "^7.0.1",
-        "request": "^2.87.0",
-        "swagger-parser": "^10.0.2",
-        "uuidjs": "^4.0.3",
-        "validator": "^13.1.17",
-        "verror": "^1.8.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.2.1"
-        }
-      }
-    },
-    "swagger-parser": {
-      "version": "10.0.2",
-      "requires": {
-        "@apidevtools/swagger-parser": "10.0.2"
       }
     },
     "symbol-tree": {
@@ -40468,7 +40113,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
+        "postcss": "^8.4.35",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
         "postcss-load-config": "^4.0.1",
@@ -40598,7 +40243,7 @@
         "@jridgewell/trace-mapping": "^0.3.20",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
+        "serialize-javascript": "^6.0.2",
         "terser": "^5.26.0"
       },
       "dependencies": {
@@ -40705,13 +40350,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "tr46": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
@@ -40766,12 +40404,14 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
-      "version": "0.14.5"
+      "version": "0.14.5",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -41151,12 +40791,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
-    "uuid": {
-      "version": "3.3.3"
-    },
-    "uuidjs": {
-      "version": "4.2.8"
-    },
     "v8-to-istanbul": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
@@ -41179,9 +40813,6 @@
         "builtins": "^5.0.0"
       }
     },
-    "validator": {
-      "version": "13.5.2"
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -41189,6 +40820,7 @@
     },
     "verror": {
       "version": "1.10.0",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -41593,7 +41225,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3"
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
     },
     "workbox-background-sync": {
       "version": "6.6.0",
@@ -41697,11 +41331,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "jsonpointer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-          "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
         },
         "source-map": {
           "version": "0.8.0-beta.0",
@@ -42017,20 +41646,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-    },
-    "z-schema": {
-      "version": "4.2.3",
-      "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^12.0.0"
-      },
-      "dependencies": {
-        "validator": {
-          "version": "12.2.0"
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,13 @@
   "private": true,
   "dependencies": {
     "axios": "^1.6.7",
-    "lodash": "^4.17.21",
     "prop-types": "15.8.1",
     "react": "^18.2.0",
     "react-dom": "18.2.0",
     "react-router": "^6.22.1",
     "react-router-dom": "^6.22.1",
     "react-scripts": "^5.0.1",
-    "spectre.css": "^0.5.9",
-    "swagger-mock-validator": "^10.0.0"
+    "spectre.css": "^0.5.9"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -47,7 +45,6 @@
     "@testing-library/jest-dom": "6.4.2",
     "@types/eslint": "~8.56.3",
     "@types/lint-staged": "~13.3.0",
-    "@types/lodash": "~4.14.202",
     "@types/prop-types": "~15.7.11",
     "@types/react": "~18.2.58",
     "@types/react-dom": "~18.2.19",
@@ -56,7 +53,6 @@
     "babel-eslint": "^10.1.0",
     "cross-env": "^7.0.3",
     "cypress": "^13.6.6",
-    "dotenv": "^8.2.0",
     "eslint": "^8.56.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-cypress": "^2.15.1",


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates dependencies in the package-lock.json file, removes lodash and swagger-mock-validator, and updates DevDependencies including pact-cypress-adapter, jest-dom, eslint, and lint-staged.
> 
> ## What changed
> - Removed lodash, dotenv and swagger-mock-validator
> 
> ## How to test
> - Review the changes in the package.json file
> - Ensure that the removed dependencies are no longer present
> - Test the functionality of the updated DevDependencies
> 
> ## Why make this change
> - Updating dependencies ensures compatibility and security
> - Removing unnecessary dependencies can improve performance
> - Updating DevDependencies can enhance development processes and tools
</details>